### PR TITLE
Use stdc++ for default build.

### DIFF
--- a/pybinaryen/build_ffi_module.py
+++ b/pybinaryen/build_ffi_module.py
@@ -48,7 +48,7 @@ def parse_header_file():
 headerfile, ffi_c_source = parse_header_file()
 ffibuilder = FFI()
 ffibuilder.cdef(headerfile)
-ffibuilder.set_source("_binaryen", ffi_c_source, libraries=['binaryen'])
+ffibuilder.set_source("_binaryen", ffi_c_source, libraries=['binaryen', 'stdc++'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This was necessary for me to use binaryen in the way I described in #3. Not sure if it causes any issues for other types of installations.